### PR TITLE
site auto width

### DIFF
--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -32,6 +32,7 @@ $link-active-color: #d9e4eb;
 #wrapper {
   @include container;
   margin: 0;
+  width: auto;
 }
 #header {
   > h1 {


### PR DESCRIPTION
overrode fixed 950px width of wrapper to allow header (and site content) to flow and wrap with the window size
